### PR TITLE
requirements.txt for getting the right environment fast

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+Flask==0.10.1
+funcsigs==0.4
+itsdangerous==0.24
+Jinja2==2.8
+MarkupSafe==0.23
+matplotlib==1.4.3
+mock==1.3.0
+mpld3==0.2
+nose==1.3.7
+numpy==1.9.2
+pbr==1.8.0
+pyparsing==2.0.3
+python-dateutil==2.4.2
+pytz==2015.4
+scipy==0.16.0
+six==1.9.0
+Werkzeug==0.10.4


### PR DESCRIPTION
this will allow people to do `pip install -R requirements.txt` and get all their requirements in one go. I ran `pip install scipy numpy flask matplotlib mpld3` in a fresh virtualenv and tested the stubs by running `python runserver.py` and was able to display everything. If anything is missing, its easy to update the requirements file. 
